### PR TITLE
techpack: Fix compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ endif
 
 LINUXINCLUDE    += \
                 -I$(srctree)/techpack/audio/include/elliptic
-obj-y += dsp/elliptic
 
 obj-y += soc/
 obj-y += dsp/

--- a/asoc/codecs/Kbuild
+++ b/asoc/codecs/Kbuild
@@ -195,6 +195,7 @@ ifeq ($(KERNEL_BUILD), 1)
 	obj-y	+= wcd934x/
 	obj-y	+= sdm660_cdc/
 	obj-y	+= msm_sdw/
+	obj-y	+= tfa9894/
 	obj-y	+= wcd9360/
 	obj-y	+= wcd937x/
 endif


### PR DESCRIPTION
The compiler complains about `dsp/elliptic` is a directory, not a file. Remove the file reference, since elliptic is included already.

Signed-off-by: Tyler Nijmeh <tylernij@gmail.com>